### PR TITLE
URGENT: FIX api compatibility problem

### DIFF
--- a/quick_train.py
+++ b/quick_train.py
@@ -67,7 +67,10 @@ update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
 with tf.control_dependencies(update_ops):
     train_op = optimizer.minimize(loss[0], var_list=update_vars, global_step=global_step)
 
-sess.run([tf.global_variables_initializer(), tf.local_variables_initializer()])
+if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12):
+    sess.run([tf.initialize_all_variables(), tf.initialize_local_variables()])
+else: 
+    sess.run([tf.global_variables_initializer(), tf.local_variables_initializer()])
 saver_to_restore.restore(sess, "./checkpoint/yolov3.ckpt")
 saver = tf.train.Saver(max_to_keep=2)
 


### PR DESCRIPTION
Dear developers,

I found some compatibility problems in your use of TensorFlow APIs, which might lead to crashes in a low version of TensorFlow. And I fix it for you as below:

`tf.global_variables_initializer` is the updated version of `tf.initialize_all_variables`, however, it appears until tf 0.12.0-rc0. So for version before that, it's better to use `tf.initialize_all_variables` to be safe.

`tf.local_variables_initializer` is the updated version of `tf.initialize_local_variables`, however, it also appears until tf 0.12.0-rc0. So for version before that, it's better to use `tf.initialize_local_variables` instead.

@willbattel @yiran7324 @YunYang1994 
Hope you could take my advice and look forward to your reply! 😄 