### PR TITLE
 Remove the COLOR_BGR2RGB of the input image

### DIFF
--- a/image_demo.py
+++ b/image_demo.py
@@ -25,7 +25,6 @@ input_size      = 416
 graph           = tf.Graph()
 
 original_image = cv2.imread(image_path)
-original_image = cv2.cvtColor(original_image, cv2.COLOR_BGR2RGB)
 original_image_size = original_image.shape[:2]
 image_data = utils.image_preporcess(np.copy(original_image), [input_size, input_size])
 image_data = image_data[np.newaxis, ...]
@@ -44,6 +43,7 @@ pred_bbox = np.concatenate([np.reshape(pred_sbbox, (-1, 5 + num_classes)),
 
 bboxes = utils.postprocess_boxes(pred_bbox, original_image_size, input_size, 0.3)
 bboxes = utils.nms(bboxes, 0.45, method='nms')
+original_image = cv2.cvtColor(original_image, cv2.COLOR_BGR2RGB)
 image = utils.draw_bbox(original_image, bboxes)
 image = Image.fromarray(image)
 image.show()


### PR DESCRIPTION
 The input image is reused COLOR_BGR2RGB, causes the inference network to fail to identify the target