### PR TITLE
Checkpoint names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bin-release/
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important
 # information for Eclipse / Flash Builder.
+
+/checkpoint/*

--- a/core/config.py
+++ b/core/config.py
@@ -39,13 +39,14 @@ __C.TRAIN                       = edict()
 __C.TRAIN.ANNOT_PATH            = "./data/dataset/voc_train.txt"
 __C.TRAIN.BATCH_SIZE            = 6
 __C.TRAIN.INPUT_SIZE            = [320, 352, 384, 416, 448, 480, 512, 544, 576, 608]
-__C.TRAIN.DATA_AUG              = True
+__C.TRAIN.DATA_AUG              = False
 __C.TRAIN.LEARN_RATE_INIT       = 1e-4
 __C.TRAIN.LEARN_RATE_END        = 1e-6
 __C.TRAIN.WARMUP_EPOCHS         = 2
 __C.TRAIN.FISRT_STAGE_EPOCHS    = 20
 __C.TRAIN.SECOND_STAGE_EPOCHS   = 30
 __C.TRAIN.INITIAL_WEIGHT        = "./checkpoint/yolov3_coco_demo.ckpt"
+__C.TRAIN.CHECKPOINT_PATH       = "./checkpoint/yolov3_test_loss={test_epoch_loss:.4f}.ckpt"
 
 
 

--- a/train.py
+++ b/train.py
@@ -34,6 +34,7 @@ class YoloTrain(object):
         self.second_stage_epochs = cfg.TRAIN.SECOND_STAGE_EPOCHS
         self.warmup_periods      = cfg.TRAIN.WARMUP_EPOCHS
         self.initial_weight      = cfg.TRAIN.INITIAL_WEIGHT
+        self.ckpt_file           = cfg.TRAIN.CHECKPOINT_PATH
         self.time                = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime(time.time()))
         self.moving_ave_decay    = cfg.YOLO.MOVING_AVE_DECAY
         self.max_bbox_per_scale  = 150
@@ -173,11 +174,10 @@ class YoloTrain(object):
                 test_epoch_loss.append(test_step_loss)
 
             train_epoch_loss, test_epoch_loss = np.mean(train_epoch_loss), np.mean(test_epoch_loss)
-            ckpt_file = "./checkpoint/yolov3_test_loss=%.4f.ckpt" % test_epoch_loss
             log_time = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time()))
             print("=> Epoch: %2d Time: %s Train loss: %.2f Test loss: %.2f Saving %s ..."
                             %(epoch, log_time, train_epoch_loss, test_epoch_loss, ckpt_file))
-            self.saver.save(self.sess, ckpt_file, global_step=epoch)
+            self.saver.save(self.sess, self.ckpt_file, global_step=epoch)
 
 
 


### PR DESCRIPTION
Adding parameter to config file for checkpoint names.
Uses f strings so any variable can be used in filename, but example keeps with the spirit of the original code.