### PR TITLE
Found a bug in mAP/extra/remove_space.py

### DIFF
--- a/mAP/extra/remove_space.py
+++ b/mAP/extra/remove_space.py
@@ -35,7 +35,7 @@ def query_yes_no(question, default="yes", bypass=False):
   while True:
     sys.stdout.write(question + prompt)
     if bypass:
-        break
+        return True # if `force yes confirmation` return True
     if sys.version_info[0] == 3:
       choice = input().lower() # if version 3 of Python
     else:


### PR DESCRIPTION
Hello!

I've found and fixed a bug in `mAP/extra/remove_space.py`'s `line 38`. It's not working when I forcing the `yes` confirmation on yes/no query using `--yes` argument. I change
```
    if bypass:
        break
```
to
```
    if bypass:
        return True # if `force yes confirmation` return True
```
That's all!
Peace~